### PR TITLE
Don't show upgrade button for server under maintenance

### DIFF
--- a/app/src/main/java/com/protonvpn/android/ui/home/countries/CountryViewHolder.kt
+++ b/app/src/main/java/com/protonvpn/android/ui/home/countries/CountryViewHolder.kt
@@ -83,14 +83,16 @@ abstract class CountryViewHolder(private val viewModel: CountryListViewModel, pr
                     if (vpnCountry.getKeywords().contains("tor")) VISIBLE else GONE
 
             root.setOnClickListener {
-                if (vpnCountry.hasAccessibleServer(viewModel.userData)) {
-                    expandableGroup.onToggleExpanded()
-                    if (expandableGroup.isExpanded) {
-                        onExpanded(position)
+                if (!vpnCountry.isUnderMaintenance()) {
+                    if (vpnCountry.hasAccessibleServer(viewModel.userData)) {
+                        expandableGroup.onToggleExpanded()
+                        if (expandableGroup.isExpanded) {
+                            onExpanded(position)
+                        }
+                        adjustCross(buttonCross, expandableGroup.isExpanded, 300)
+                    } else {
+                        clickedOnUpgradeCountry()
                     }
-                    adjustCross(buttonCross, expandableGroup.isExpanded, 300)
-                } else {
-                    clickedOnUpgradeCountry()
                 }
             }
 


### PR DESCRIPTION
For a server under maintenance, the current v2.0.21 shows an upgrade button upon tap, even though I'm a Plus user.

<img src=https://user-images.githubusercontent.com/33295590/72973629-e7840380-3dcd-11ea-9e40-adb0d518cbd8.jpg width=250>

This PR fixes this. As a side effect, Free users won't see the upgrade button anymore either if they tap on a country under maintenance. I would argue however that this constitutes a sensible separation:

* offline countries => cannot connect anyway, show nothing upon tap.
* online countries => show *Connect* or *Upgrade*, depending on your subscription.