### PR TITLE
Use Material save icon in activity_profile

### DIFF
--- a/app/src/main/res/drawable/ic_save.xml
+++ b/app/src/main/res/drawable/ic_save.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/fab_margin"
-            app:srcCompat="@android:drawable/ic_menu_save" />
+            app:srcCompat="@drawable/ic_save" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
Use the [`save` icon](https://material.io/resources/icons/?icon=save&style=baseline) from the Material icons instead of the outdated Holo icon.

The source of the icon is Android Studio's "New->Vector Asset ->Clip Art".

<img src=https://user-images.githubusercontent.com/33295590/79636213-617e1b80-8176-11ea-9db7-cd866140f56e.jpg height=450>    ==>    <img src=https://user-images.githubusercontent.com/33295590/79636212-60e58500-8176-11ea-83eb-d60594744108.jpg height=450>
