### PR TITLE
Add touch states

### DIFF
--- a/app/src/main/res/layout/item_proton_switch.xml
+++ b/app/src/main/res/layout/item_proton_switch.xml
@@ -23,6 +23,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:foreground="?attr/selectableItemBackground"
     tools:background="@color/dimmedGrey">
 
     <androidx.appcompat.widget.SwitchCompat


### PR DESCRIPTION
Adds a touch state to the ProtonSwitch and to the Secure Core switches in the main screen and the profiles activity.

I would like to see touch states on the "Next" and "Skip" buttons of the onboarding and the "Got it" button of the Onboarding Dialogs as well, but those won't be one-line changes so I'll leave them for later.

You might notice that I'm a great advocate of touch states :)