### PR TITLE
Exclude DebugProbesKt from APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -241,6 +241,7 @@ android {
     }
 
     packagingOptions {
+        exclude "DebugProbesKt.bin"
         exclude 'META-INF/DEPENDENCIES.txt'
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'


### PR DESCRIPTION
https://github.com/Kotlin/kotlinx.coroutines#avoiding-including-the-debug-infrastructure-in-the-resulting-apk