### PR TITLE
Open app on long pressing quick setting tile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
             android:theme="@style/ProtonTheme.Splash.Vpn.Dark">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>


### PR DESCRIPTION
Adding the action `QS_TILE_PREFERENCES` to an activity makes android open that particular activity instead of the app info screen in settings app when the quick setting tile is long pressed.

Adding this action to the SplashScreen makes it a bit easier to switch between servers.
> Maybe this could have been added to SettingsDefaultProfileActivity but it made more sense to link it with SplashScreen rather than default profile activity as opening the app for changing server would happen more than changing the default quick connect setting.